### PR TITLE
Fix timeout reporting success

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/installer/BiThrowingFunction.java
+++ b/src/main/java/com/synopsys/integration/blackduck/installer/BiThrowingFunction.java
@@ -1,0 +1,11 @@
+package com.synopsys.integration.blackduck.installer;
+
+public interface BiThrowingFunction<T, R, E1 extends Throwable, E2 extends Throwable> {
+    /**
+     * Applies this function, which may throw two different exceptions, to the given argument.
+     * @param t the function argument
+     * @return the function result
+     */
+    R apply(T t) throws E1, E2;
+
+}

--- a/src/main/java/com/synopsys/integration/blackduck/installer/configure/BlackDuckWaitJobTask.java
+++ b/src/main/java/com/synopsys/integration/blackduck/installer/configure/BlackDuckWaitJobTask.java
@@ -53,6 +53,7 @@ public class BlackDuckWaitJobTask implements WaitJobTask {
 
     @Override
     public boolean isComplete() throws BlackDuckInstallerException {
+        intLogger.info(String.format("Attempting to connect to %s.", blackDuckServerConfig.getBlackDuckUrl()));
         BlackDuckServicesFactory blackDuckServicesFactory = blackDuckServerConfig.createBlackDuckServicesFactory(intLogger);
         BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
         try {


### PR DESCRIPTION
When Alert OR BD does not come back successful within the polling window configured with blackduck.install.timeout.in.seconds, the installer is reporting that the install was successful when it was not:

```
: Try #20 (elapsed: 00:09:30.169)...not done yet, waiting 30 seconds and trying again...
: The Black Duck install was successful!
: Black Duck will now be configured.
: Attempting to update the registration id...
: No previous registration was found - attempting to create one...
: The installer could not complete successfully: Could not perform the authorization request: Connect to int-relcandi.dc1.lan:443 [int-relcandi.dc1.lan/10.1.65.132] failed: Connection refused (Connection refused)
```

This change addresses that, and adds an additional logging line on each attempted connection to BD, similar to Alert:

```
: Attempting to connect to https://int-relcandi.dc1.lan.
: Couldn't check the version because the Black Duck server is not responding successfully yet.
: Try #1 (elapsed: 00:00:00.000)...not done yet, waiting 30 seconds and trying again...
: Attempting to connect to https://int-relcandi.dc1.lan.
: Couldn't check the version because the Black Duck server is not responding successfully yet.
: Try #2 (elapsed: 00:00:30.043)...not done yet, waiting 30 seconds and trying again...
: The installer could not complete successfully: Black Duck did not respond within the configured timeout period, the install can not continue - please check the output for any errors.
```